### PR TITLE
Login fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kross-sdk",
-  "version": "1.0.7-beta.115",
+  "version": "1.0.7-beta.119",
   "description": "90days SDK for login, sigup and loans",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/kross-client/base.ts
+++ b/src/kross-client/base.ts
@@ -54,12 +54,15 @@ export class KrossClientBase {
       },
       async (error: AxiosError) => {
         // Access Token was expired
-        if (error?.response?.status === 401) {
+        if (
+          error?.response?.status === 401 &&
+          error?.config?.url !== '/auth/login'
+        ) {
           await this.updateAuthToken();
           return this.instance.request(error.config);
         } else {
           console.log('Error in axios response interceptor', { ...error });
-          return Promise.resolve(error.response);
+          return Promise.reject(error.response);
         }
       }
     );


### PR DESCRIPTION
on login fail refresh token was getting called and also resolving promise on error now we instead reject so that we can show error to user in frontend