### PR TITLE
Provide storage in option

### DIFF
--- a/__test__/kross-client/account.tsx
+++ b/__test__/kross-client/account.tsx
@@ -2,12 +2,10 @@ import { QueryClient, QueryClientProvider } from 'react-query';
 import { Account } from '../../src/kross-client/account';
 import React from 'react';
 import { act, renderHook, waitFor } from '@testing-library/react';
-
+import axios from 'axios';
 export const account = () => {
   let client: Account;
   const baseURL = 'https://olive-dev.kross.kr';
-  const accessId = 'XLD7UY9GETOK7TPY';
-  const secretKey = 'yLbVRHGgwT5c22ndOVT2';
   const queryClient = new QueryClient({
     defaultOptions: {
       queries: {
@@ -21,10 +19,12 @@ export const account = () => {
   );
 
   beforeAll(() => {
+    const axiosClient = axios.create({
+      baseURL,
+    });
     client = new Account({
       baseURL,
-      accessId,
-      secretKey,
+      instance: axiosClient,
       adapter: require('axios/lib/adapters/http'),
     });
   });

--- a/__test__/kross-client/account.tsx
+++ b/__test__/kross-client/account.tsx
@@ -2,10 +2,11 @@ import { QueryClient, QueryClientProvider } from 'react-query';
 import { Account } from '../../src/kross-client/account';
 import React from 'react';
 import { act, renderHook, waitFor } from '@testing-library/react';
-import axios from 'axios';
 export const account = () => {
   let client: Account;
   const baseURL = 'https://olive-dev.kross.kr';
+  const accessId = 'XLD7UY9GETOK7TPY';
+  const secretKey = 'yLbVRHGgwT5c22ndOVT2';
   const queryClient = new QueryClient({
     defaultOptions: {
       queries: {
@@ -19,12 +20,10 @@ export const account = () => {
   );
 
   beforeAll(() => {
-    const axiosClient = axios.create({
-      baseURL,
-    });
     client = new Account({
       baseURL,
-      instance: axiosClient,
+      accessId,
+      secretKey,
       adapter: require('axios/lib/adapters/http'),
     });
   });

--- a/__test__/kross-client/base.tsx
+++ b/__test__/kross-client/base.tsx
@@ -2,12 +2,11 @@ import { QueryClient, QueryClientProvider } from 'react-query';
 import { KrossClient } from '../../src/kross-client';
 import React from 'react';
 import { act, renderHook, waitFor } from '@testing-library/react';
+import axios from 'axios';
 
 export const base = () => {
   let client: KrossClient;
   const baseURL = 'https://olive-dev.kross.kr';
-  const accessId = 'XLD7UY9GETOK7TPY';
-  const secretKey = 'yLbVRHGgwT5c22ndOVT2';
   const queryClient = new QueryClient({
     defaultOptions: {
       queries: {
@@ -20,10 +19,12 @@ export const base = () => {
     <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
   );
   beforeAll(() => {
+    const axiosClient = axios.create({
+      baseURL,
+    });
     client = new KrossClient({
       baseURL,
-      accessId,
-      secretKey,
+      instance: axiosClient,
       adapter: require('axios/lib/adapters/http'),
     });
   });

--- a/__test__/kross-client/base.tsx
+++ b/__test__/kross-client/base.tsx
@@ -2,11 +2,12 @@ import { QueryClient, QueryClientProvider } from 'react-query';
 import { KrossClient } from '../../src/kross-client';
 import React from 'react';
 import { act, renderHook, waitFor } from '@testing-library/react';
-import axios from 'axios';
 
 export const base = () => {
   let client: KrossClient;
   const baseURL = 'https://olive-dev.kross.kr';
+  const accessId = 'XLD7UY9GETOK7TPY';
+  const secretKey = 'yLbVRHGgwT5c22ndOVT2';
   const queryClient = new QueryClient({
     defaultOptions: {
       queries: {
@@ -19,12 +20,10 @@ export const base = () => {
     <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
   );
   beforeAll(() => {
-    const axiosClient = axios.create({
-      baseURL,
-    });
     client = new KrossClient({
       baseURL,
-      instance: axiosClient,
+      accessId,
+      secretKey,
       adapter: require('axios/lib/adapters/http'),
     });
   });

--- a/__test__/kross-client/investment.tsx
+++ b/__test__/kross-client/investment.tsx
@@ -2,11 +2,12 @@ import { QueryClient, QueryClientProvider } from 'react-query';
 import { Investments } from '../../src/kross-client/investments';
 import React from 'react';
 import { act, renderHook, waitFor } from '@testing-library/react';
-import axios from 'axios';
 
 export const investment = () => {
   let client: Investments;
   const baseURL = 'https://olive-dev.kross.kr';
+  const accessId = 'XLD7UY9GETOK7TPY';
+  const secretKey = 'yLbVRHGgwT5c22ndOVT2';
   const queryClient = new QueryClient({
     defaultOptions: {
       queries: {
@@ -20,12 +21,10 @@ export const investment = () => {
   );
 
   beforeAll(() => {
-    const axiosClient = axios.create({
-      baseURL,
-    });
     client = new Investments({
       baseURL,
-      instance: axiosClient,
+      accessId,
+      secretKey,
       adapter: require('axios/lib/adapters/http'),
     });
   });

--- a/__test__/kross-client/investment.tsx
+++ b/__test__/kross-client/investment.tsx
@@ -2,12 +2,11 @@ import { QueryClient, QueryClientProvider } from 'react-query';
 import { Investments } from '../../src/kross-client/investments';
 import React from 'react';
 import { act, renderHook, waitFor } from '@testing-library/react';
+import axios from 'axios';
 
 export const investment = () => {
   let client: Investments;
   const baseURL = 'https://olive-dev.kross.kr';
-  const accessId = 'XLD7UY9GETOK7TPY';
-  const secretKey = 'yLbVRHGgwT5c22ndOVT2';
   const queryClient = new QueryClient({
     defaultOptions: {
       queries: {
@@ -21,10 +20,12 @@ export const investment = () => {
   );
 
   beforeAll(() => {
+    const axiosClient = axios.create({
+      baseURL,
+    });
     client = new Investments({
       baseURL,
-      accessId,
-      secretKey,
+      instance: axiosClient,
       adapter: require('axios/lib/adapters/http'),
     });
   });
@@ -102,7 +103,7 @@ export const investment = () => {
 
   it('transactionHistory', async () => {
     const { transactionHistory } = client.useInvestmentHooks();
-    const { result } = renderHook(() => transactionHistory({}), {
+    const { result } = renderHook(() => transactionHistory(), {
       wrapper,
     });
     await waitFor(async () => {

--- a/__test__/kross-client/loan.tsx
+++ b/__test__/kross-client/loan.tsx
@@ -2,11 +2,12 @@ import { QueryClient, QueryClientProvider } from 'react-query';
 import { Loans } from '../../src/kross-client/loans';
 import React from 'react';
 import { renderHook, waitFor } from '@testing-library/react';
-import axios from 'axios';
 
 export const loan = () => {
   let client: Loans;
   const baseURL = 'https://olive-dev.kross.kr';
+  const accessId = 'XLD7UY9GETOK7TPY';
+  const secretKey = 'yLbVRHGgwT5c22ndOVT2';
 
   const queryClient = new QueryClient({
     defaultOptions: {
@@ -21,12 +22,10 @@ export const loan = () => {
   );
 
   beforeAll(() => {
-    const axiosClient = axios.create({
-      baseURL,
-    });
     client = new Loans({
       baseURL,
-      instance: axiosClient,
+      accessId,
+      secretKey,
       adapter: require('axios/lib/adapters/http'),
     });
   });

--- a/__test__/kross-client/loan.tsx
+++ b/__test__/kross-client/loan.tsx
@@ -2,12 +2,12 @@ import { QueryClient, QueryClientProvider } from 'react-query';
 import { Loans } from '../../src/kross-client/loans';
 import React from 'react';
 import { renderHook, waitFor } from '@testing-library/react';
+import axios from 'axios';
 
 export const loan = () => {
   let client: Loans;
   const baseURL = 'https://olive-dev.kross.kr';
-  const accessId = 'XLD7UY9GETOK7TPY';
-  const secretKey = 'yLbVRHGgwT5c22ndOVT2';
+
   const queryClient = new QueryClient({
     defaultOptions: {
       queries: {
@@ -21,10 +21,12 @@ export const loan = () => {
   );
 
   beforeAll(() => {
+    const axiosClient = axios.create({
+      baseURL,
+    });
     client = new Loans({
       baseURL,
-      accessId,
-      secretKey,
+      instance: axiosClient,
       adapter: require('axios/lib/adapters/http'),
     });
   });

--- a/__test__/kross-client/user.tsx
+++ b/__test__/kross-client/user.tsx
@@ -2,11 +2,10 @@ import { QueryClient, QueryClientProvider } from 'react-query';
 import { User } from '../../src/kross-client/user';
 import React from 'react';
 import { act, renderHook, waitFor } from '@testing-library/react';
+import axios from 'axios';
 export const user = () => {
   let client: User;
   const baseURL = 'https://olive-dev.kross.kr';
-  const accessId = 'XLD7UY9GETOK7TPY';
-  const secretKey = 'yLbVRHGgwT5c22ndOVT2';
   const queryClient = new QueryClient({
     defaultOptions: {
       queries: {
@@ -20,10 +19,12 @@ export const user = () => {
   );
 
   beforeAll(() => {
+    const axiosClient = axios.create({
+      baseURL,
+    });
     client = new User({
       baseURL,
-      accessId,
-      secretKey,
+      instance: axiosClient,
       adapter: require('axios/lib/adapters/http'),
     });
   });

--- a/__test__/kross-client/user.tsx
+++ b/__test__/kross-client/user.tsx
@@ -2,10 +2,12 @@ import { QueryClient, QueryClientProvider } from 'react-query';
 import { User } from '../../src/kross-client/user';
 import React from 'react';
 import { act, renderHook, waitFor } from '@testing-library/react';
-import axios from 'axios';
+
 export const user = () => {
   let client: User;
   const baseURL = 'https://olive-dev.kross.kr';
+  const accessId = 'XLD7UY9GETOK7TPY';
+  const secretKey = 'yLbVRHGgwT5c22ndOVT2';
   const queryClient = new QueryClient({
     defaultOptions: {
       queries: {
@@ -19,12 +21,10 @@ export const user = () => {
   );
 
   beforeAll(() => {
-    const axiosClient = axios.create({
-      baseURL,
-    });
     client = new User({
       baseURL,
-      instance: axiosClient,
+      accessId,
+      secretKey,
       adapter: require('axios/lib/adapters/http'),
     });
   });

--- a/package.json
+++ b/package.json
@@ -62,8 +62,6 @@
   },
   "homepage": "https://github.com/ninetydays/sign-SDK#readme",
   "dependencies": {
-    "@react-native-async-storage/async-storage": "^1.17.11",
-    "@types/base-64": "^1.0.0",
     "axios": "^0.27.2",
     "base-64": "^1.0.0",
     "crypto-browserify": "^3.12.0",
@@ -72,7 +70,6 @@
     "stream-browserify": "^3.0.0"
   },
   "peerDependencies": {
-    "@react-native-async-storage/async-storage": "^1.17.11",
     "react": "^18.1.0",
     "react-native": "*",
     "react-query": "*"

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,3 +4,4 @@ export * from './kross-client/account';
 export * from './kross-client/investments';
 export * from './kross-client/loans';
 export * from './kross-client/user';
+export * from './utils/encryptor';

--- a/src/kross-client/account.ts
+++ b/src/kross-client/account.ts
@@ -12,7 +12,6 @@ import {
   AccountWithdrawCancelDto,
   AccountWithdrawCancelResponse,
 } from '../types';
-import AsyncStorage from '@react-native-async-storage/async-storage';
 import { parseJwt } from '../utils/encryptor';
 
 export class Account extends KrossClientBase {
@@ -45,12 +44,16 @@ export class Account extends KrossClientBase {
       accountWithdrawVerifyDto
     );
   }
-  async withdrawInit(amount: number) {
-    const authToken = await AsyncStorage.getItem('authToken');
-    const userData = await parseJwt(authToken as string);
+  async withdrawInit(amount: number, member_no?: number) {
+    let userData: any;
+    if (this.storage) {
+      const authToken = await this.storage.getItem('authToken');
+      userData = await parseJwt(authToken as string);
+    }
+
     const accountWithdrawInitDto = {
       amount,
-      member_no: userData.member_no,
+      member_no: this.storage ? userData.member_no : member_no,
     };
     return this.instance.post<AccountWithdrawInitResponse>(
       '/accounts/withdraw/init',

--- a/src/kross-client/account.ts
+++ b/src/kross-client/account.ts
@@ -12,7 +12,6 @@ import {
   AccountWithdrawCancelDto,
   AccountWithdrawCancelResponse,
 } from '../types';
-import { parseJwt } from '../utils/encryptor';
 
 export class Account extends KrossClientBase {
   withdrawCancel: FunctionRegistered<
@@ -44,20 +43,10 @@ export class Account extends KrossClientBase {
       accountWithdrawVerifyDto
     );
   }
-  async withdrawInit(amount: number, member_no?: number) {
-    let userData: any;
-    if (this.storage) {
-      const authToken = await this.storage.getItem('authToken');
-      userData = await parseJwt(authToken as string);
-    }
-
-    const accountWithdrawInitDto = {
-      amount,
-      member_no: this.storage ? userData.member_no : member_no,
-    };
+  async withdrawInit(accountWithdrawInitDto: AccountWithdrawInitDto) {
     return this.instance.post<AccountWithdrawInitResponse>(
       '/accounts/withdraw/init',
-      accountWithdrawInitDto as AccountWithdrawInitDto
+      accountWithdrawInitDto
     );
   }
 
@@ -70,8 +59,9 @@ export class Account extends KrossClientBase {
         return mutation;
       },
       withdrawInit: () => {
-        const mutation = useMutation((amount: number) =>
-          this.withdrawInit(amount)
+        const mutation = useMutation(
+          (accountWithdrawInitDto: AccountWithdrawInitDto) =>
+            this.withdrawInit(accountWithdrawInitDto)
         );
         return mutation;
       },

--- a/src/kross-client/base.ts
+++ b/src/kross-client/base.ts
@@ -31,7 +31,7 @@ export class KrossClientBase {
         };
 
         if (options?.refreshTokenCallback) {
-          config = await options.refreshTokenCallback(config, hmacToken);
+          await options.refreshTokenCallback(config, hmacToken);
         }
 
         return config;

--- a/src/kross-client/loans.ts
+++ b/src/kross-client/loans.ts
@@ -9,7 +9,6 @@ import {
   LoanRepaymentResponse,
   LoansQueryDto,
 } from '../types/kross-client/loans';
-import { parseJwt } from '../utils/encryptor';
 export class Loans extends KrossClientBase {
   loanData: FunctionRegistered<LoansQueryDto, LoansResponse>;
   loanRepayments: FunctionRegistered<LoansQueryDto, LoanRepaymentResponse>;
@@ -69,12 +68,6 @@ export class Loans extends KrossClientBase {
         return useInfiniteQuery(
           'loanData',
           async ({ pageParam = 0 }) => {
-            let userData: any;
-            if (this?.storage) {
-              const authToken = await this.storage.getItem('authToken');
-              userData = await parseJwt(authToken as string);
-            }
-
             const skip = (
               pageParam * parseInt(loansQueryDto?.take as string, 10)
             ).toString();
@@ -86,9 +79,9 @@ export class Loans extends KrossClientBase {
             const loansArray = Object.values(loan?.data);
             const loansResponseArray = await loansArray.map(
               (item: any): LoansResponse => {
-                if (userData?.user_id || userId) {
-                  const investment = item.investments.find((invItem: any) =>
-                    invItem?.userId == this.storage ? userData.user_id : userId
+                if (userId) {
+                  const investment = item.investments.find(
+                    (invItem: any) => invItem?.userId == userId
                   );
                   return {
                     ...item,

--- a/src/kross-client/loans.ts
+++ b/src/kross-client/loans.ts
@@ -10,7 +10,6 @@ import {
   LoansQueryDto,
 } from '../types/kross-client/loans';
 import { parseJwt } from '../utils/encryptor';
-import AsyncStorage from '@react-native-async-storage/async-storage';
 export class Loans extends KrossClientBase {
   loanData: FunctionRegistered<LoansQueryDto, LoansResponse>;
   loanRepayments: FunctionRegistered<LoansQueryDto, LoanRepaymentResponse>;
@@ -66,12 +65,16 @@ export class Loans extends KrossClientBase {
           });
         });
       },
-      loanData: (loansQueryDto: LoansQueryDto) => {
+      loanData: (loansQueryDto: LoansQueryDto, userId?: string) => {
         return useInfiniteQuery(
           'loanData',
           async ({ pageParam = 0 }) => {
-            const authToken = await AsyncStorage.getItem('authToken');
-            const userData = await parseJwt(authToken as string);
+            let userData: any;
+            if (this?.storage) {
+              const authToken = await this.storage.getItem('authToken');
+              userData = await parseJwt(authToken as string);
+            }
+
             const skip = (
               pageParam * parseInt(loansQueryDto?.take as string, 10)
             ).toString();
@@ -83,9 +86,9 @@ export class Loans extends KrossClientBase {
             const loansArray = Object.values(loan?.data);
             const loansResponseArray = await loansArray.map(
               (item: any): LoansResponse => {
-                if (userData?.user_id) {
-                  const investment = item.investments.find(
-                    (invItem: any) => invItem?.userId == userData.user_id
+                if (userData?.user_id || userId) {
+                  const investment = item.investments.find((invItem: any) =>
+                    invItem?.userId == this.storage ? userData.user_id : userId
                   );
                   return {
                     ...item,

--- a/src/kross-client/user.ts
+++ b/src/kross-client/user.ts
@@ -170,6 +170,8 @@ export class User extends KrossClientBase {
               return res.data;
             });
           },
+
+          enabled: userQueryDto?.enabled || true,
         });
       },
 

--- a/src/kross-client/user.ts
+++ b/src/kross-client/user.ts
@@ -170,8 +170,8 @@ export class User extends KrossClientBase {
               return res.data;
             });
           },
-
-          enabled: userQueryDto?.enabled || true,
+          enabled:
+            userQueryDto?.enabled === undefined ? true : userQueryDto?.enabled,
         });
       },
 

--- a/src/types/kross-client/index.ts
+++ b/src/types/kross-client/index.ts
@@ -10,6 +10,7 @@ export type KrossClientOptions = AxiosRequestConfig & {
   baseURL: string;
   accessId: string;
   secretKey: string;
+  storage?: any;
 };
 
 export type FunctionOptions = {

--- a/src/types/kross-client/index.ts
+++ b/src/types/kross-client/index.ts
@@ -1,4 +1,4 @@
-import { AxiosRequestConfig, AxiosResponse } from 'axios';
+import { AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios';
 export * from './account';
 export * from './investments';
 export * from './loans';
@@ -8,9 +8,7 @@ export * from './account';
 
 export type KrossClientOptions = AxiosRequestConfig & {
   baseURL: string;
-  accessId: string;
-  secretKey: string;
-  storage?: any;
+  instance: AxiosInstance;
 };
 
 export type FunctionOptions = {

--- a/src/types/kross-client/index.ts
+++ b/src/types/kross-client/index.ts
@@ -1,4 +1,4 @@
-import { AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios';
+import { AxiosRequestConfig, AxiosResponse } from 'axios';
 export * from './account';
 export * from './investments';
 export * from './loans';
@@ -6,9 +6,19 @@ export * from './user';
 export * from './investments';
 export * from './account';
 
+type RefreshTokenCallback = (
+  config: AxiosRequestConfig,
+  hmacToken: {
+    hmacToken: string;
+    xDate: string;
+  }
+) => Promise<AxiosRequestConfig>;
+
 export type KrossClientOptions = AxiosRequestConfig & {
   baseURL: string;
-  instance: AxiosInstance;
+  accessId: string;
+  secretKey: string;
+  refreshTokenCallback?: RefreshTokenCallback;
 };
 
 export type FunctionOptions = {

--- a/src/types/kross-client/index.ts
+++ b/src/types/kross-client/index.ts
@@ -8,11 +8,8 @@ export * from './account';
 
 type RefreshTokenCallback = (
   config: AxiosRequestConfig,
-  hmacToken: {
-    hmacToken: string;
-    xDate: string;
-  }
-) => Promise<AxiosRequestConfig>;
+  hmacToken: { hmacToken: string; xDate: string }
+) => Promise<AxiosRequestConfig | undefined>;
 
 export type KrossClientOptions = AxiosRequestConfig & {
   baseURL: string;

--- a/src/types/kross-client/user.ts
+++ b/src/types/kross-client/user.ts
@@ -8,6 +8,7 @@ export type UserQueryDto = {
   group_by?: string;
   query?: Record<string, unknown>;
   include?: Record<string, unknown>;
+  enabled?: boolean;
 };
 export type kftcBalanceResponseData = {
   rsp_code: string;

--- a/src/utils/encryptor.ts
+++ b/src/utils/encryptor.ts
@@ -1,5 +1,4 @@
 import { createHmac } from 'crypto';
-import base64 from 'base-64';
 export const hmacHashString = (secretKey: string, message: string) => {
   const hmac = createHmac('sha256', secretKey);
   hmac.update(message);
@@ -19,14 +18,3 @@ export const hmacTokenFunction =
       xDate: date,
     };
   };
-
-export const parseJwt = async (authToken: string) => {
-  if (!authToken) {
-    return;
-  }
-
-  const [, payload] = authToken.split('.');
-
-  const payloadDecoded = JSON.parse(base64.decode(payload));
-  return payloadDecoded;
-};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -52,8 +52,6 @@ module.exports = {
     'react-dom': 'ReactDOM',
     'react-native': 'react-native',
     'react-query': 'react-query',
-    '@react-native-async-storage/async-storage':
-      '@react-native-async-storage/async-storage',
     'date-fns': 'date-fns',
   },
 


### PR DESCRIPTION
removed storage and interceptors from here and handled them in app instead so that the package can be used in all 3 envs
broswer/node/RN

There are breaking changes. Now client will accept two props 

```
new KrossClient({
baseURL,
instance // which is an axios config
});

instance will be 
axios.create({
  baseURL: envVariables.baseURL as string,
});
```

package is also exposing **hmacTokenFunction** to generate hmacToken and X-Date headers like

```
const getHmacToken = await hmacTokenFunction(
    envVariables.accessId as string,
    envVariables.secretKey as string,
  );

  const hmacToken = await getHmacToken(config.method);

  config.headers = {
    ...config.headers,
    'client-authorization': hmacToken.hmacToken,
    'X-Date': hmacToken.xDate,
  };
  ```
