### PR TITLE
chore: fix loan & investment join

### DIFF
--- a/__test__/kross-client/loan.tsx
+++ b/__test__/kross-client/loan.tsx
@@ -30,7 +30,7 @@ export const loan = () => {
     });
   });
 
-  it.only('gets authToken and refreshToken', async () => {
+  it('gets authToken and refreshToken', async () => {
     const { useLogin } = client.useAuthHooks();
     const { result } = renderHook(() => useLogin(), {
       wrapper,
@@ -94,7 +94,7 @@ export const loan = () => {
     });
   }, 30000);
 
-  it.only('gets list of the loans available', async () => {
+  it('gets list of the loans available', async () => {
     const { loanData } = client.useLoanHooks();
     const { result } = renderHook(
       () =>

--- a/__test__/kross-client/loan.tsx
+++ b/__test__/kross-client/loan.tsx
@@ -30,7 +30,7 @@ export const loan = () => {
     });
   });
 
-  it('gets authToken and refreshToken', async () => {
+  it.only('gets authToken and refreshToken', async () => {
     const { useLogin } = client.useAuthHooks();
     const { result } = renderHook(() => useLogin(), {
       wrapper,
@@ -94,21 +94,23 @@ export const loan = () => {
     });
   }, 30000);
 
-  it('gets list of the loans available', async () => {
+  it.only('gets list of the loans available', async () => {
     const { loanData } = client.useLoanHooks();
     const { result } = renderHook(
       () =>
         loanData({
-          filter: 'state||$eq||funding||pending',
-          take: '1',
-        }),
+          filter: 'state||$in||funding,pending',
+          take: '5',
+        },
+        '14218',
+        ),
       {
         wrapper,
       }
     );
     await waitFor(() => {
       const { data } = result.current;
-      expect(data).toBeDefined();
+      expect(data?.pages).toBeDefined();
     });
   }, 30000);
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kross-sdk",
-  "version": "1.0.8-beta.326",
+  "version": "1.0.8-beta.327",
   "description": "90days SDK for login, sigup and loans",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/kross-client/loans.ts
+++ b/src/kross-client/loans.ts
@@ -80,12 +80,12 @@ export class Loans extends KrossClientBase {
               skip,
             });
             const loansArray = Object.values(loan?.data);
-            const loansResponseArray = await loansArray.map(
+            const loansResponseArray = loansArray.map(
               (item: any): LoansResponse => {
-                if (userId) {
-                  const investment = item.investments.find(
-                    (invItem: any) => invItem?.userId == userId
-                  );
+                const investment = item.investments.find(
+                  (invItem: any) => invItem?.userId == userId
+                );
+                if (userId  && investment?.state != 'cancelled') {
                   return {
                     ...item,
                     isUserInvested: investment ? true : false,

--- a/src/kross-client/loans.ts
+++ b/src/kross-client/loans.ts
@@ -82,10 +82,11 @@ export class Loans extends KrossClientBase {
             const loansArray = Object.values(loan?.data);
             const loansResponseArray = loansArray.map(
               (item: any): LoansResponse => {
-                const investment = item.investments.find(
-                  (invItem: any) => invItem?.userId == userId
+                const investments = item.investments.filter(
+                  (invItem: any) => invItem?.userId == userId && invItem?.state != 'cancelled'
                 );
-                if (userId  && investment?.state != 'cancelled') {
+                if (userId && investments.length > 0) {
+                  const investment = investments[0];
                   return {
                     ...item,
                     isUserInvested: investment ? true : false,

--- a/src/kross-client/loans.ts
+++ b/src/kross-client/loans.ts
@@ -83,7 +83,7 @@ export class Loans extends KrossClientBase {
             const loansResponseArray = loansArray.map(
               (item: any): LoansResponse => {
                 const investments = item.investments.filter(
-                  (investmentItem: any) => investmentItem?.userId == userId && investmentItem?.state != 'cancelled'
+                  (investment: any) => investment?.userId == userId && investment?.state != 'cancelled'
                 );
                 if (userId && investments.length > 0) {
                   const investment = investments[0];

--- a/src/kross-client/loans.ts
+++ b/src/kross-client/loans.ts
@@ -83,7 +83,7 @@ export class Loans extends KrossClientBase {
             const loansResponseArray = loansArray.map(
               (item: any): LoansResponse => {
                 const investments = item.investments.filter(
-                  (invItem: any) => invItem?.userId == userId && invItem?.state != 'cancelled'
+                  (investmentItem: any) => investmentItem?.userId == userId && investmentItem?.state != 'cancelled'
                 );
                 if (userId && investments.length > 0) {
                   const investment = investments[0];


### PR DESCRIPTION
If current investment has been cancelled than when we refetch the data it should ignore while joining cos we can re-invest cancelled product again.