### PR TITLE
chore: get only funding list

### DIFF
--- a/src/kross-client/user.ts
+++ b/src/kross-client/user.ts
@@ -199,7 +199,7 @@ export class User extends KrossClientBase {
               {
                 params: {
                   select: 'id,amount',
-                  filter: 'state||$in||funding,funded,pending',
+                  filter: 'state||$eq||funding',
                 },
               }
             );


### PR DESCRIPTION
As far as I know, we only get funding products for InvestmentApplied. In addition query filter was not working properly and let back-end team know about that(they are able to reproduce. 