### PR TITLE
chore: add option expire refresh

### DIFF
--- a/__test__/kross-client/loan.tsx
+++ b/__test__/kross-client/loan.tsx
@@ -42,7 +42,6 @@ export const loan = () => {
         refreshExpiresIn: 40,
       });
     });
-    console.log("login: ", result.current.data)
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(result.current.data).toBeDefined();
   });
@@ -106,7 +105,6 @@ export const loan = () => {
     );
     await waitFor(() => {
       const { data } = result.current;
-      console.log("data: ", data?.pages);
       expect(data?.pages).toBeDefined();
     });
   });

--- a/__test__/kross-client/loan.tsx
+++ b/__test__/kross-client/loan.tsx
@@ -39,9 +39,10 @@ export const loan = () => {
       await result.current.mutateAsync({
         keyid: 'mad@kross.kr',
         password: 'Kross123!',
+        refreshExpiresIn: 40,
       });
     });
-
+    console.log("login: ", result.current.data)
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(result.current.data).toBeDefined();
   });
@@ -105,6 +106,7 @@ export const loan = () => {
     );
     await waitFor(() => {
       const { data } = result.current;
+      console.log("data: ", data?.pages);
       expect(data?.pages).toBeDefined();
     });
   });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kross-sdk",
-  "version": "1.0.8-beta.327",
+  "version": "1.0.8-beta.329",
   "description": "90days SDK for login, sigup and loans",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/kross-client/base.ts
+++ b/src/kross-client/base.ts
@@ -82,12 +82,12 @@ export class KrossClientBase {
       }
     );
   }
-  login({ keyid, password, expiresIn = 15 }: LoginDto) {
+  login({ keyid, password, refreshExpiresIn}: LoginDto) {
     return this.instance
       .post<LoginResponse>('/auth/login', {
         keyid,
         password,
-        expiresIn,
+        refreshExpiresIn
       })
       .then((response) => {
         this.authToken = response.data.token;

--- a/src/kross-client/base.ts
+++ b/src/kross-client/base.ts
@@ -83,12 +83,17 @@ export class KrossClientBase {
     );
   }
   login({ keyid, password, refreshExpiresIn}: LoginDto) {
+    const loginDto = refreshExpiresIn ? {
+      keyid,
+      password,
+      refreshExpiresIn,
+    } : {
+      keyid,
+      password,
+    }
     return this.instance
-      .post<LoginResponse>('/auth/login', {
-        keyid,
-        password,
-        refreshExpiresIn
-      })
+      .post<LoginResponse>('/auth/login', 
+      loginDto)
       .then((response) => {
         this.authToken = response.data.token;
         this.refreshToken = response?.data?.refresh;

--- a/src/types/kross-client/index.ts
+++ b/src/types/kross-client/index.ts
@@ -37,7 +37,7 @@ export type FunctionRegistered<I = unknown, O = unknown> = (
 export type LoginDto = {
   keyid: string;
   password: string;
-  expiresIn?: number;
+  refreshExpiresIn?: number;
 };
 
 export type LoginResponse = {


### PR DESCRIPTION
As per the recent change in login endpoint, refreshExpiresIn added as optional add can be configured from client side by passing value for an refreshExpiresIn argument