### PR TITLE
chore: hasNextPage is not always true

### DIFF
--- a/src/kross-client/inquiry.ts
+++ b/src/kross-client/inquiry.ts
@@ -50,16 +50,19 @@ export class Inquiry extends KrossClientBase {
                 ? 0
                 : parseInt(inquiriesDto?.take as string, 10))
             ).toString();
-            return this.fetchInquiries({
+            const inquiriesData =  await this.fetchInquiries({
               ...inquiriesDto,
               skip,
-            }).then((res) => {
-              return res.data;
             });
+            const inquiriesDataArray = Object.values(inquiriesData?.data);
+            return inquiriesDataArray || [];
           },
           {
             getNextPageParam: (lastPage, pages) => {
-              return pages?.length >= 1 ? pages.length : null;
+              if (lastPage.length === 0){
+                return null;
+              }
+              return pages?.length;
             },
           }
         );

--- a/src/kross-client/investments.ts
+++ b/src/kross-client/investments.ts
@@ -127,13 +127,16 @@ export class Investments extends KrossClientBase {
         return useInfiniteQuery(
           'transactionHistory',
           async ({ pageParam = 0 }) => {
-            return this.transactionHistory(pageParam).then((res) => {
-              return res.data;
-            });
+            const transactionData = await this.transactionHistory(pageParam);
+            const transactionDataArray = Object.values(transactionData?.data);
+            return transactionDataArray || [];
           },
           {
             getNextPageParam: (lastPage, pages) => {
-              return pages?.length >= 1 ? pages.length : null;
+              if(lastPage.length === 0){
+                return null;
+              }
+              return pages?.length;
             },
           }
         );

--- a/src/kross-client/loans.ts
+++ b/src/kross-client/loans.ts
@@ -110,7 +110,7 @@ export class Loans extends KrossClientBase {
               if (lastPage.length === 0){
                 return null;
               }
-              return pages.length;
+              return pages?.length;
             },
           }
         );

--- a/src/kross-client/loans.ts
+++ b/src/kross-client/loans.ts
@@ -107,7 +107,10 @@ export class Loans extends KrossClientBase {
           },
           {
             getNextPageParam: (lastPage, pages) => {
-              return pages?.length >= 1 ? pages.length : null;
+              if (lastPage.length === 0){
+                return null;
+              }
+              return pages.length;
             },
           }
         );


### PR DESCRIPTION
The issue we had was even tho there are no more items to load it was still showing the load icon

Also, hasNextPage was always returning true. I think we could use **hasNextPage** when there are items to load rather than 
```
data?.pages.length &&
              data.pages.map(page => page).flat().length >= 3
```

<img width="317" alt="Screen Shot 2023-02-15 at 10 20 33 AM" src="https://user-images.githubusercontent.com/46732700/218907838-dcfb2823-5b28-4471-960e-da34a0b02e02.png">
