### PR TITLE
chore: have same response format for infiniteQuery

### DIFF
--- a/__test__/kross-client/inquiry.tsx
+++ b/__test__/kross-client/inquiry.tsx
@@ -76,7 +76,6 @@ export const InquiryTest = () => {
     );
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    console.log('data: ', result.current.data?.pages);
     expect(result.current.data).toBeDefined();
   });
 

--- a/__test__/kross-client/inquiry.tsx
+++ b/__test__/kross-client/inquiry.tsx
@@ -30,7 +30,7 @@ export const InquiryTest = () => {
     });
   });
 
-  it('gets authToken and refreshToken', async () => {
+  it.only('gets authToken and refreshToken', async () => {
     const { useLogin } = client.useAuthHooks();
     const { result } = renderHook(() => useLogin(), {
       wrapper,
@@ -62,7 +62,7 @@ export const InquiryTest = () => {
     expect(result.current.data).toBeDefined();
   });
 
-  it('gets inquiries list for logged in user', async () => {
+  it.only('gets inquiries list for logged in user', async () => {
     const { fetchInquiries } = client.useInquiriesHooks();
     const { result } = renderHook(
       () =>
@@ -76,6 +76,7 @@ export const InquiryTest = () => {
     );
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    console.log("data: ", result.current.data?.pages);
     expect(result.current.data).toBeDefined();
   });
 

--- a/__test__/kross-client/inquiry.tsx
+++ b/__test__/kross-client/inquiry.tsx
@@ -30,7 +30,7 @@ export const InquiryTest = () => {
     });
   });
 
-  it.only('gets authToken and refreshToken', async () => {
+  it('gets authToken and refreshToken', async () => {
     const { useLogin } = client.useAuthHooks();
     const { result } = renderHook(() => useLogin(), {
       wrapper,
@@ -62,7 +62,7 @@ export const InquiryTest = () => {
     expect(result.current.data).toBeDefined();
   });
 
-  it.only('gets inquiries list for logged in user', async () => {
+  it('gets inquiries list for logged in user', async () => {
     const { fetchInquiries } = client.useInquiriesHooks();
     const { result } = renderHook(
       () =>
@@ -76,7 +76,7 @@ export const InquiryTest = () => {
     );
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    console.log("data: ", result.current.data?.pages);
+    console.log('data: ', result.current.data?.pages);
     expect(result.current.data).toBeDefined();
   });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kross-sdk",
-  "version": "1.0.8-beta.335",
+  "version": "1.0.8-beta.344",
   "description": "90days SDK for login, sigup and loans",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/kross-client/base.ts
+++ b/src/kross-client/base.ts
@@ -82,18 +82,19 @@ export class KrossClientBase {
       }
     );
   }
-  login({ keyid, password, refreshExpiresIn}: LoginDto) {
-    const loginDto = refreshExpiresIn ? {
-      keyid,
-      password,
-      refreshExpiresIn,
-    } : {
-      keyid,
-      password,
-    }
+  login({ keyid, password, refreshExpiresIn }: LoginDto) {
+    const loginDto = refreshExpiresIn
+      ? {
+          keyid,
+          password,
+          refreshExpiresIn,
+        }
+      : {
+          keyid,
+          password,
+        };
     return this.instance
-      .post<LoginResponse>('/auth/login', 
-      loginDto)
+      .post<LoginResponse>('/auth/login', loginDto)
       .then((response) => {
         this.authToken = response.data.token;
         this.refreshToken = response?.data?.refresh;

--- a/src/kross-client/inquiry.ts
+++ b/src/kross-client/inquiry.ts
@@ -54,8 +54,8 @@ export class Inquiry extends KrossClientBase {
               ...inquiriesDto,
               skip,
             });
-            const inquiriesDataArray = Object.values(inquiriesData?.data);
-            return inquiriesDataArray || [];
+            const inquiriesDataArray = inquiriesData?.data ? Object.values(inquiriesData?.data): [];
+            return inquiriesDataArray;
           },
           {
             getNextPageParam: (lastPage, pages) => {

--- a/src/kross-client/inquiry.ts
+++ b/src/kross-client/inquiry.ts
@@ -50,16 +50,18 @@ export class Inquiry extends KrossClientBase {
                 ? 0
                 : parseInt(inquiriesDto?.take as string, 10))
             ).toString();
-            const inquiriesData =  await this.fetchInquiries({
+            const inquiriesData = await this.fetchInquiries({
               ...inquiriesDto,
               skip,
             });
-            const inquiriesDataArray = inquiriesData?.data ? Object.values(inquiriesData?.data): [];
+            const inquiriesDataArray = inquiriesData?.data
+              ? Object.values(inquiriesData?.data)
+              : [];
             return inquiriesDataArray;
           },
           {
             getNextPageParam: (lastPage, pages) => {
-              if (lastPage.length === 0){
+              if (lastPage.length === 0) {
                 return null;
               }
               return pages?.length;

--- a/src/kross-client/inquiry.ts
+++ b/src/kross-client/inquiry.ts
@@ -50,16 +50,17 @@ export class Inquiry extends KrossClientBase {
                 ? 0
                 : parseInt(inquiriesDto?.take as string, 10))
             ).toString();
-            const inquiriesData =  await this.fetchInquiries({
+            const inquiriesData = await this.fetchInquiries({
               ...inquiriesDto,
               skip,
             });
-            const inquiriesDataArray = Object.values(inquiriesData?.data);
-            return inquiriesDataArray || [];
+            const inquiriesDataArray: { [key: string]: any }[] =
+              inquiriesData?.data ? Object.values(inquiriesData.data) : [];
+            return inquiriesDataArray;
           },
           {
             getNextPageParam: (lastPage, pages) => {
-              if (lastPage.length === 0){
+              if (lastPage.length === 0) {
                 return null;
               }
               return pages?.length;

--- a/src/kross-client/inquiry.ts
+++ b/src/kross-client/inquiry.ts
@@ -55,7 +55,12 @@ export class Inquiry extends KrossClientBase {
               skip,
             });
             const inquiriesDataArray = inquiriesData?.data
-              ? Object.values(inquiriesData?.data)
+              ? Object.values(
+                  typeof inquiriesData.data === 'object' &&
+                    inquiriesData.data !== null
+                    ? inquiriesData.data
+                    : {}
+                )
               : [];
             return inquiriesDataArray;
           },

--- a/src/kross-client/inquiry.ts
+++ b/src/kross-client/inquiry.ts
@@ -50,18 +50,16 @@ export class Inquiry extends KrossClientBase {
                 ? 0
                 : parseInt(inquiriesDto?.take as string, 10))
             ).toString();
-            const inquiriesData = await this.fetchInquiries({
+            const inquiriesData =  await this.fetchInquiries({
               ...inquiriesDto,
               skip,
             });
-            const inquiriesDataArray = Array.isArray(inquiriesData?.data)
-              ? inquiriesData.data
-              : [];
-            return inquiriesDataArray;
+            const inquiriesDataArray = Object.values(inquiriesData?.data);
+            return inquiriesDataArray || [];
           },
           {
             getNextPageParam: (lastPage, pages) => {
-              if (lastPage.length === 0) {
+              if (lastPage.length === 0){
                 return null;
               }
               return pages?.length;

--- a/src/kross-client/inquiry.ts
+++ b/src/kross-client/inquiry.ts
@@ -54,14 +54,7 @@ export class Inquiry extends KrossClientBase {
               ...inquiriesDto,
               skip,
             });
-            const inquiriesDataArray = inquiriesData?.data
-              ? Object.values(
-                  typeof inquiriesData.data === 'object' &&
-                    inquiriesData.data !== null
-                    ? inquiriesData.data
-                    : {}
-                )
-              : [];
+            const inquiriesDataArray = Object.values(inquiriesData?.data ?? {});
             return inquiriesDataArray;
           },
           {

--- a/src/kross-client/inquiry.ts
+++ b/src/kross-client/inquiry.ts
@@ -54,7 +54,9 @@ export class Inquiry extends KrossClientBase {
               ...inquiriesDto,
               skip,
             });
-            const inquiriesDataArray = Object.values(inquiriesData?.data ?? {});
+            const inquiriesDataArray = Array.isArray(inquiriesData?.data)
+              ? inquiriesData.data
+              : [];
             return inquiriesDataArray;
           },
           {

--- a/src/kross-client/investments.ts
+++ b/src/kross-client/investments.ts
@@ -128,8 +128,9 @@ export class Investments extends KrossClientBase {
           'transactionHistory',
           async ({ pageParam = 0 }) => {
             const transactionData = await this.transactionHistory(pageParam);
-            const transactionDataArray = Object.values(transactionData?.data);
-            return transactionDataArray || [];
+            const transactionDataArray = transactionData?.data?.data 
+              ? Object.values(transactionData.data.data) : [];
+            return transactionDataArray;
           },
           {
             getNextPageParam: (lastPage, pages) => {

--- a/src/kross-client/investments.ts
+++ b/src/kross-client/investments.ts
@@ -128,13 +128,14 @@ export class Investments extends KrossClientBase {
           'transactionHistory',
           async ({ pageParam = 0 }) => {
             const transactionData = await this.transactionHistory(pageParam);
-            const transactionDataArray = transactionData?.data?.data 
-              ? Object.values(transactionData.data.data) : [];
+            const transactionDataArray = transactionData?.data?.data
+              ? Object.values(transactionData.data.data)
+              : [];
             return transactionDataArray;
           },
           {
             getNextPageParam: (lastPage, pages) => {
-              if(lastPage.length === 0){
+              if (lastPage.length === 0) {
                 return null;
               }
               return pages?.length;

--- a/src/kross-client/loans.ts
+++ b/src/kross-client/loans.ts
@@ -83,7 +83,9 @@ export class Loans extends KrossClientBase {
             const loansResponseArray = loansArray.map(
               (item: any): LoansResponse => {
                 const investments = item.investments.filter(
-                  (investment: any) => investment?.userId == userId && investment?.state != 'cancelled'
+                  (investment: any) =>
+                    investment?.userId == userId &&
+                    investment?.state != 'cancelled'
                 );
                 if (userId && investments.length > 0) {
                   const investment = investments[0];
@@ -107,7 +109,7 @@ export class Loans extends KrossClientBase {
           },
           {
             getNextPageParam: (lastPage, pages) => {
-              if (lastPage.length === 0){
+              if (lastPage.length === 0) {
                 return null;
               }
               return pages?.length;

--- a/src/types/kross-client/inquiry.ts
+++ b/src/types/kross-client/inquiry.ts
@@ -5,7 +5,7 @@ export type InquiryDto = {
   detail: string;
   response?: string;
 };
-export type InquiryResponseDto = {
+export type InquiryResponseData = {
   id: string;
   userId: string;
   type: string;
@@ -28,4 +28,4 @@ export type UpdateInquiryDto = {
   response: string;
 };
 
-export type InquiryResponse = FunctionResponse<InquiryResponseDto>;
+export type InquiryResponse = FunctionResponse<InquiryResponseData>;

--- a/src/types/kross-client/loans.ts
+++ b/src/types/kross-client/loans.ts
@@ -50,6 +50,7 @@ export type LoanResponseData = {
   userInvestedAmount?: number;
   isUserInvested?: boolean;
   investmentId?: number | null;
+  reservedAt: Date;
 };
 
 export type LoansResponse = FunctionResponse<LoanResponseData>;


### PR DESCRIPTION
@Jscripter-pk Made other infiniteQueries have same format with Loans we have. 
response -> response.pages, response.pageParam -> response.pages.data
Previously data had another response status and data. It is confusing to parse.
Also, inquiry page and account page were failing. Please use 1.0.8-beta.344 for stable version.