### PR TITLE
Fix response type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kross-sdk",
-  "version": "1.0.8-beta.510",
+  "version": "1.0.8-beta.511",
   "description": "90days SDK for login, sigup and loans",
   "main": "dist/index.js",
   "browser": "dist/index.web.js",

--- a/src/kross-client/account.ts
+++ b/src/kross-client/account.ts
@@ -19,16 +19,16 @@ import {
 
 export class Account extends KrossClientBase {
   withdrawCancel: FunctionRegistered<
-    AccountWithdrawCancelDto,
-    AccountWithdrawCancelResponse
+    AccountWithdrawCancelResponse,
+    AccountWithdrawCancelDto
   >;
 
   constructor(options: KrossClientOptions) {
     super(options);
 
     this.withdrawCancel = Account.registerFunction<
-      AccountWithdrawCancelDto,
-      AccountWithdrawCancelResponse
+      AccountWithdrawCancelResponse,
+      AccountWithdrawCancelDto
     >({
       url: '/accounts/withdraw/cancel',
       urlParam: 'idempotency_key',

--- a/src/kross-client/base.ts
+++ b/src/kross-client/base.ts
@@ -170,9 +170,9 @@ export class KrossClientBase {
     return this.instance.request<T>(options);
   }
 
-  static registerFunction<I = unknown, O = unknown>(
+  static registerFunction<O = unknown, I = unknown>(
     options: FunctionOptions
-  ): (input?: I) => Promise<AxiosResponse<O>> {
+  ): (input?: I) => Promise<AxiosResponse<O, I>> {
     return function (
       this: KrossClientBase,
       input?: I

--- a/src/kross-client/inquiry.ts
+++ b/src/kross-client/inquiry.ts
@@ -10,17 +10,17 @@ import { useMutation, useQuery, useInfiniteQuery } from 'react-query';
 import { FunctionRegistered, KrossClientOptions } from '../types';
 
 export class Inquiry extends KrossClientBase {
-  createInquiry: FunctionRegistered<InquiryDto, InquiryResponse>;
-  fetchInquiries: FunctionRegistered<InquiriesDto>;
+  createInquiry: FunctionRegistered<InquiryResponse, InquiryDto>;
+  fetchInquiries: FunctionRegistered<unknown, InquiriesDto>;
 
   constructor(options: KrossClientOptions) {
     super(options);
 
-    this.createInquiry = Inquiry.registerFunction<InquiryDto, InquiryResponse>({
+    this.createInquiry = Inquiry.registerFunction<InquiryResponse, InquiryDto>({
       url: '/inquiries',
       method: 'post',
     });
-    this.fetchInquiries = Inquiry.registerFunction<InquiriesDto>({
+    this.fetchInquiries = Inquiry.registerFunction<unknown, InquiriesDto>({
       url: '/inquiries',
       method: 'get',
     });

--- a/src/kross-client/investments.ts
+++ b/src/kross-client/investments.ts
@@ -14,33 +14,33 @@ import {
 } from '../types/kross-client/investments';
 export class Investments extends KrossClientBase {
   investmentList: FunctionRegistered<
-    InvestmentsWengeQueryDto,
-    InvestmentListResponse
+    InvestmentListResponse,
+    InvestmentsWengeQueryDto
   >;
-  notes: FunctionRegistered<InvestmentsWengeQueryDto, NotesResponse>;
-  cmsTradebook: FunctionRegistered<InvestmentQueryDto, CmsTradebookResponse>;
+  notes: FunctionRegistered<NotesResponse, InvestmentsWengeQueryDto>;
+  cmsTradebook: FunctionRegistered<CmsTradebookResponse, InvestmentQueryDto>;
 
   constructor(options: KrossClientOptions) {
     super(options);
     this.cmsTradebook = Investments.registerFunction<
-      InvestmentQueryDto,
-      CmsTradebookResponse
+      CmsTradebookResponse,
+      InvestmentQueryDto
     >({
       url: '/cms-tradebooks',
       method: 'get',
     });
 
     this.notes = Investments.registerFunction<
-      InvestmentsWengeQueryDto,
-      NotesResponse
+      NotesResponse,
+      InvestmentsWengeQueryDto
     >({
       url: '/notes',
       method: 'get',
     });
 
     this.investmentList = Investments.registerFunction<
-      InvestmentsWengeQueryDto,
-      InvestmentListResponse
+      InvestmentListResponse,
+      InvestmentsWengeQueryDto
     >({
       url: '/investments',
       method: 'get',

--- a/src/kross-client/loans.ts
+++ b/src/kross-client/loans.ts
@@ -14,34 +14,34 @@ import {
   LoanResponseData,
 } from '../types/kross-client/loans';
 export class Loans extends KrossClientBase {
-  loanData: FunctionRegistered<LoansQueryDto, LoansResponse>;
-  loanRepayments: FunctionRegistered<LoansQueryDto, LoanRepaymentResponse>;
-  loanConfigs: FunctionRegistered<LoansQueryDto, LoanConfigResponse>;
-  loanDetail: FunctionRegistered<LoanDetailQueryDto, LoanDetailResponse>;
+  loanData: FunctionRegistered<LoansResponse, LoansQueryDto>;
+  loanRepayments: FunctionRegistered<LoanRepaymentResponse, LoansQueryDto>;
+  loanConfigs: FunctionRegistered<LoanConfigResponse, LoansQueryDto>;
+  loanDetail: FunctionRegistered<LoanDetailResponse, LoanDetailQueryDto>;
   constructor(options: KrossClientOptions) {
     super(options);
     this.loanConfigs = Loans.registerFunction<
-      LoansQueryDto,
-      LoanConfigResponse
+      LoanConfigResponse,
+      LoansQueryDto
     >({
       url: '/loan-configs',
       method: 'get',
     });
 
     this.loanRepayments = Loans.registerFunction<
-      LoansQueryDto,
-      LoanRepaymentResponse
+      LoanRepaymentResponse,
+      LoansQueryDto
     >({
       url: '/loan-repayments',
       method: 'get',
     });
-    this.loanData = Loans.registerFunction<LoansQueryDto, LoansResponse>({
+    this.loanData = Loans.registerFunction<LoansResponse, LoansQueryDto>({
       url: '/loans',
       method: 'get',
     });
     this.loanDetail = Loans.registerFunction<
-      LoanDetailQueryDto,
-      LoanDetailResponse
+      LoanDetailResponse,
+      LoanDetailQueryDto
     >({
       url: '/loan-detail',
       method: 'get',

--- a/src/kross-client/user.ts
+++ b/src/kross-client/user.ts
@@ -33,34 +33,34 @@ export class User extends KrossClientBase {
   kftcBalance: FunctionRegistered<kftcBalanceResponse>;
   getVirtualAccCertificate: FunctionRegistered<AccountCertificateResponse>;
   checkVirtualAccount: FunctionRegistered<VirtualAccountCheckResponse>;
-  registerMember: FunctionRegistered<UserRegisterDto, GetAuthTokenResponse>;
+  registerMember: FunctionRegistered<GetAuthTokenResponse, UserRegisterDto>;
   unRegisterMemeber: FunctionRegistered<WelcomeUnregisterResponse>;
   releaseDepositControl: FunctionRegistered<ReleaseDepositResponse>;
-  accountData: FunctionRegistered<UserQueryDto, AccountResponse>;
-  userData: FunctionRegistered<UserQueryDto, UserResponse>;
-  userDataUpdate: FunctionRegistered<UserUpdateDto, UserUpdateResponse>;
-  passwordCheck: FunctionRegistered<PasswordCheckDto, PasswordCheckResponse>;
+  accountData: FunctionRegistered<AccountResponse, UserQueryDto>;
+  userData: FunctionRegistered<UserResponse, UserQueryDto>;
+  userDataUpdate: FunctionRegistered<UserUpdateResponse, UserUpdateDto>;
+  passwordCheck: FunctionRegistered<PasswordCheckResponse, PasswordCheckDto>;
 
   userAccountLogs: FunctionRegistered<
-    UserWengeQueryDto,
-    UserAccountLogsResponse
+    UserAccountLogsResponse,
+    UserWengeQueryDto
   >;
-  userNoteLogs: FunctionRegistered<UserWengeQueryDto, UserNoteLogsResponse>;
+  userNoteLogs: FunctionRegistered<UserNoteLogsResponse, UserWengeQueryDto>;
   portfolio: FunctionRegistered<PortfolioResponse>;
 
   constructor(options: KrossClientOptions) {
     super(options);
     this.userNoteLogs = User.registerFunction<
-      UserWengeQueryDto,
-      UserNoteLogsResponse
+      UserNoteLogsResponse,
+      UserWengeQueryDto
     >({
       url: '/user-note-logs',
       method: 'get',
     });
 
     this.userAccountLogs = User.registerFunction<
-      UserWengeQueryDto,
-      UserAccountLogsResponse
+      UserAccountLogsResponse,
+      UserWengeQueryDto
     >({
       url: '/user-account-logs',
       method: 'get',
@@ -84,8 +84,8 @@ export class User extends KrossClientBase {
       });
 
     this.registerMember = User.registerFunction<
-      UserRegisterDto,
-      GetAuthTokenResponse
+      GetAuthTokenResponse,
+      UserRegisterDto
     >({
       url: '/users',
       method: 'post',
@@ -101,27 +101,27 @@ export class User extends KrossClientBase {
       method: 'patch',
     });
 
-    this.accountData = User.registerFunction<UserQueryDto, AccountResponse>({
+    this.accountData = User.registerFunction<AccountResponse, UserQueryDto>({
       url: '/users/account',
       method: 'get',
     });
 
-    this.userData = User.registerFunction<UserQueryDto, UserResponse>({
+    this.userData = User.registerFunction<UserResponse, UserQueryDto>({
       url: '/users',
       method: 'get',
     });
 
     this.userDataUpdate = User.registerFunction<
-      UserUpdateDto,
-      UserUpdateResponse
+      UserUpdateResponse,
+      UserUpdateDto
     >({
       url: '/users',
       method: 'put',
     });
 
     this.passwordCheck = User.registerFunction<
-      PasswordCheckDto,
-      PasswordCheckResponse
+      PasswordCheckResponse,
+      PasswordCheckDto
     >({
       url: '/users/password-check',
       method: 'post',

--- a/src/types/kross-client/index.ts
+++ b/src/types/kross-client/index.ts
@@ -30,7 +30,7 @@ export type FunctionResponse<T = unknown> = {
   message?: string;
 };
 
-export type FunctionRegistered<I = unknown, O = unknown> = (
+export type FunctionRegistered<O = unknown, I = unknown> = (
   input?: I
 ) => Promise<AxiosResponse<O>>;
 


### PR DESCRIPTION
Some methods don't have a query parameter as the expected argument, which can result an unknown response type when we try to call the kross-client method that doesn't accept the query parameter. I fixed this by simply change the argument order:

```diff
- FunctionRegistered<QueryParamOrByBodyType, ResponseType>
+ FunctionRegistered<ResponseType, QueryParamOrByBodyType>