### PR TITLE
refreshToken expires in 30days in login

### DIFF
--- a/src/kross-client/base.ts
+++ b/src/kross-client/base.ts
@@ -87,16 +87,12 @@ export class KrossClientBase {
       }
     );
   }
-  login({ keyid, password, refreshExpiresIn }: LoginDto) {
-    const loginDto = refreshExpiresIn
-      ? {
+  login({ keyid, password}: LoginDto) {
+    const expiresIn30Days = 60 * 24 * 30;
+    const loginDto = {
           keyid,
           password,
-          refreshExpiresIn,
-        }
-      : {
-          keyid,
-          password,
+          refreshExpiresIn: expiresIn30Days,
         };
     return this.instance
       .post<LoginResponse>('/auth/login', loginDto)


### PR DESCRIPTION
If do not set refreshExpireIn then refreshToken will have infinite expireDate.
logout will be handled in app/web/client side.

![expire30Days](https://user-images.githubusercontent.com/46732700/233934334-08d2c38d-24da-4e9b-9334-48ebdf9e4baf.jpg)
